### PR TITLE
Add try/catch to JSON parsing code

### DIFF
--- a/q-xhr.js
+++ b/q-xhr.js
@@ -224,12 +224,8 @@
 
   Q.xhr.defaults = {
     transformResponse: [function(data, headers) {
-      if (typeof data === 'string' && (headers('content-type') || '').indexOf('json') >= 0) {
-        try {
+      if (typeof data === 'string' && data.length && (headers('content-type') || '').indexOf('json') >= 0) {
           data = JSON.parse(data);
-        } catch (e) {
-          return data;
-        }
       }
       return data
     }],

--- a/q-xhr.js
+++ b/q-xhr.js
@@ -225,7 +225,7 @@
   Q.xhr.defaults = {
     transformResponse: [function(data, headers) {
       if (typeof data === 'string' && data.length && (headers('content-type') || '').indexOf('json') >= 0) {
-          data = JSON.parse(data);
+        data = JSON.parse(data);
       }
       return data
     }],

--- a/q-xhr.js
+++ b/q-xhr.js
@@ -225,7 +225,11 @@
   Q.xhr.defaults = {
     transformResponse: [function(data, headers) {
       if (typeof data === 'string' && (headers('content-type') || '').indexOf('json') >= 0) {
-        data = JSON.parse(data)
+        try {
+          data = JSON.parse(data);
+        } catch (e) {
+          return data;
+        }
       }
       return data
     }],


### PR DESCRIPTION
I have an API endpoint that returns a status code of 201, but no data when sent a POST. This triggers the error handler (JSON.parse throws an error if it's malformed). 

I believe the success handler should still be triggered since the HTTP request was successful, so this PR swallows any JSON parse errors.