### PR TITLE
Notifications for xhr.upload.onprogress

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ Post some JSON:
   })
 ```
 
+Listen to progress:
+
+```javascript
+  
+  var someLargeData = getSomeLargeData();
+  
+  Q.xhr.post('/processLargeData', someLargeData).progress(function(progress) {
+    if (progress.upload) {
+      console.log('Uploaded: '+progress.loaded+' bytes')
+    } else {
+      console.log('Downloaded: '+progress.loaded+' bytes')
+    }
+  }).then(function(resp) {
+    console.log('success!')
+  })
+```
+
 With modern web applications in mind, `application/json` is the default mime type.
 
 ### Differences from [Angular's $http][$http]
@@ -42,7 +59,7 @@ On the topic of MVC frameworks not needing jQuery, The [Angular] devs have adopt
 - **No JSONP.** JSONP has all sorts of security flaws and limitations and causes lots of burden on both client side and server side code. Given that [XDomainRequest is available for IE8 and 9](http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx), and IE6 and 7 [are dead](http://gs.statcounter.com/#desktop-browser_version_partially_combined-ww-monthly-201302-201402), it should be avoided IMO. If you want XDomainRequest support (which jQuery never did), let me know or submit a pull request!
 - **Interceptors are applied in order.** I guess [angular] had some backward compatibility they were tied to do so something funky by applying request handlers in reverse but response handlers in order, but I don't have backward compatibility issues so it works like you'd expect.
 - **The default JSON transform is only applied if the response content is `application/json`**. [Angular] was doing something odd by sniffing all content via regex matching and then converting it to JSON if it matched. Why? Geez people set your `Content-Type` correctly already. Not to mention content sniffing leads to [security issues](http://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx).
-- **Progress support**. Supply a progress listener function to recieve [ProgressEvent](https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent)s.
+- **Progress support**. Supply a progress listener function to recieve [ProgressEvent](https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent)s. q-xhr listens to both upload and download progress. To help you detect the type of progress, q-xhr adds the boolean property `upload` to the `ProgressEvent` object.
 
 ### Installation
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "q-xhr",
   "main": "q-xhr.js",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "homepage": "https://github.com/nathanboktae/q-xhr",
   "authors": [
     "Nathan Black <nathan@nathanblack.org>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q-xhr",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "description": "XMLHttpRequest (ajax) using powerful Q promises",
   "author": "Nathan Black <nathan@nathanblack.org>",
   "main": "q-xhr.js",

--- a/q-xhr.js
+++ b/q-xhr.js
@@ -189,6 +189,10 @@
         config.withCredentials = defaults.withCredentials
       }
 
+      if (config.watchUpload == null && defaults.watchUpload != null) {
+        config.watchUpload = defaults.watchUpload
+      }
+
       // send request
       return sendReq(config, reqData, headers).then(transformResponse, transformResponse)
     },
@@ -298,6 +302,13 @@
 
     xhr.onprogress = function (progress) {
       deferred.notify(progress)
+    }
+
+    if(config.watchUpload && xhr.upload) {
+      xhr.upload.onprogress = function (progress) {
+        progress.upload = true; // flag to differentiate from xhr.onprogress
+        deferred.notify(progress)
+      }
     }
 
     if (config.withCredentials) {

--- a/q-xhr.js
+++ b/q-xhr.js
@@ -189,10 +189,6 @@
         config.withCredentials = defaults.withCredentials
       }
 
-      if (config.watchUpload == null && defaults.watchUpload != null) {
-        config.watchUpload = defaults.watchUpload
-      }
-
       // send request
       return sendReq(config, reqData, headers).then(transformResponse, transformResponse)
     },
@@ -301,12 +297,13 @@
     }
 
     xhr.onprogress = function (progress) {
+      progress.upload = false
       deferred.notify(progress)
     }
 
-    if(config.watchUpload && xhr.upload) {
+    if (xhr.upload) {
       xhr.upload.onprogress = function (progress) {
-        progress.upload = true; // flag to differentiate from xhr.onprogress
+        progress.upload = true
         deferred.notify(progress)
       }
     }

--- a/test/unit.tests.coffee
+++ b/test/unit.tests.coffee
@@ -89,16 +89,35 @@ describe 'q-xhr', ->
       inFlight: ->
         xhr.withCredentials.should.be.true
 
-  it 'should send progress notifications', (done) ->
+  it 'should send progress notifications during upload', (done) ->
+    if !window.XMLHttpRequestUpload
+      done()
+      return
+    
     Q.xhr(
       url: '/foo'
     ).progress (prog) ->
-      prog.should.equal 'progress!'
+      prog.upload.should.equal true
+      prog.should.equal 'upload progress!'
       done()
 
     scenario
       inFlight: ->
-        xhr.onprogress('progress!')
+        xhr.upload.onprogress('upload progress!')
+    return
+
+
+  it 'should send progress notifications during download', (done) ->
+    Q.xhr(
+      url: '/foo'
+    ).progress (prog) ->
+      prog.upload.should.equal false
+      prog.should.equal 'download progress!'
+      done()
+
+    scenario
+      inFlight: ->
+        xhr.onprogress('download progress!')
     return
 
   describe 'params', ->


### PR DESCRIPTION
Hi,
Currently, `q-xhr` uses `deferred.notify` to track the progression of the download of the response. It would be nice to be able to track the upload when available.

Angular's $http being backed by $q, they don't have the `deferred.notify` API so it's not possible to copy their implementation. (it's the goal of your lib if I'm not mistaken ?)
Still, [reacting to progress is a popular feature](https://github.com/angular/angular.js/issues/1934) so here is a proposition for the implementation:

 * To avoid to break compatibility with applications expecting `Q.xhr({...}).progress` to only trigger on download progress, applications have to explicitly ask for upload progress notifications with the new config property `watchUpload` (boolean).

 * It's possible to set `Q.xhr.defaults.watchUpload = true`

 * Since there will be two sorts of `progress` calls, it should be possible to differentiate them. Both type of progress objects are instances of [ProgressEvent](https://developer.mozilla.org/fr/docs/Web/API/ProgressEvent). To differentiate them, it's possible to use:
    ````js
    Q
      .xhr({url: '/foo', method: 'GET', watchUpload: true})
      .progress(function(progress) {
        if(window.XMLHttpRequestUpload && progress.target instanceof XMLHttpRequestUpload) {
          // upload progress
        }else{
          // download progress
        }
      })
    ````
    `window.XMLHttpRequestUpload` is a quick feature detection to avoid to throw on `progress.target instanceof undefined` when executed on older browsers.

    This test on the user side does not seem like a good idea (hard to maintain, boilerplate) so I add the flag `upload` when the progress event is received by the `upload.onprogress` callback. This way, the above example becomes simply:
    ````js
    Q
      .xhr({url: '/foo', method: 'GET', watchUpload: true})
      .progress(function(progress) {
        if(progress.upload) {
          // upload progress
        }else{
          // download progress
        }
      })
	````

What do you think about it ? (Maybe the names of the option and flag should change ?)